### PR TITLE
Feat: show conflict details - v1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gitmerge-action",
-  "version": "1.0.18",
+  "version": "1.0.20",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gitmerge-action",
-      "version": "1.0.18",
+      "version": "1.0.20",
       "license": "ISC",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gitmerge-action",
-  "version": "1.0.16",
+  "version": "1.0.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gitmerge-action",
-      "version": "1.0.16",
+      "version": "1.0.18",
       "license": "ISC",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gitmerge-action",
-  "version": "1.0.20",
+  "version": "1.0.22",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gitmerge-action",
-      "version": "1.0.20",
+      "version": "1.0.22",
       "license": "ISC",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gitmerge-action",
-  "version": "1.0.37",
+  "version": "1.0.38",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gitmerge-action",
-      "version": "1.0.37",
+      "version": "1.0.38",
       "license": "ISC",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gitmerge-action",
-  "version": "1.0.2",
+  "version": "1.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gitmerge-action",
-      "version": "1.0.2",
+      "version": "1.0.14",
       "license": "ISC",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gitmerge-action",
-  "version": "1.0.22",
+  "version": "1.0.37",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gitmerge-action",
-      "version": "1.0.22",
+      "version": "1.0.37",
       "license": "ISC",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gitmerge-action",
-  "version": "1.0.14",
+  "version": "1.0.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gitmerge-action",
-      "version": "1.0.14",
+      "version": "1.0.16",
       "license": "ISC",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitmerge-action",
-  "version": "1.0.14",
+  "version": "1.0.16",
   "description": "Native Github action to make merge and deploy from repo",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitmerge-action",
-  "version": "1.0.18",
+  "version": "1.0.20",
   "description": "Native Github action to make merge and deploy from repo",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitmerge-action",
-  "version": "1.0.37",
+  "version": "1.0.38",
   "description": "Native Github action to make merge and deploy from repo",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitmerge-action",
-  "version": "1.0.2",
+  "version": "1.0.14",
   "description": "Native Github action to make merge and deploy from repo",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitmerge-action",
-  "version": "1.0.20",
+  "version": "1.0.22",
   "description": "Native Github action to make merge and deploy from repo",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitmerge-action",
-  "version": "1.0.22",
+  "version": "1.0.37",
   "description": "Native Github action to make merge and deploy from repo",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitmerge-action",
-  "version": "1.0.16",
+  "version": "1.0.18",
   "description": "Native Github action to make merge and deploy from repo",
   "main": "index.js",
   "scripts": {

--- a/src/helper.js
+++ b/src/helper.js
@@ -31,12 +31,18 @@ async function createAuxBranch(commitSha) {
 async function deleteBranch(branchName) {
     console.log(`Deleting branch ${branchName}`)
 
-    await octokit.rest.git.deleteRef({
-        ...repoInfo,
-        ref: branchName
-    })
-
-    console.log('Successful delete branch')
+    try {
+        await octokit.rest.git.deleteRef({
+            ...repoInfo,
+            ref: branchName,
+        })   
+        console.log('Successful delete branch')
+    } catch (error) {
+        if (error.message !== 'Reference does not exist') {
+            throw Error('Unexpected error on delete branch')
+        }
+        console.warn('Branch does not exists');
+    }
 }
 
 async function mergeBranchs(pullHeadRef) {

--- a/src/helper.js
+++ b/src/helper.js
@@ -15,8 +15,7 @@ async function getLastCommitSha() {
         ref: ref
     })
 
-    console.log(`Successful get commit.
-    Commit message: ${data.commit.message}`);
+    console.log(`Successful get commit with message: ${data.commit.message}`);
 
     return data.sha
 }
@@ -55,6 +54,20 @@ async function getPrs() {
     })
 
     let prs = data.filter(pr => !pr.draft)
+
+    const merges = prs.map(async(pr) => {
+        const res = await octokit.request('GET /repos/{owner}/{repo}/pulls/{pull_number}', {
+            ...repoInfo,
+            pull_number: pr.number
+        })
+        
+        console.log( {
+            pr: pr.number,
+            mergeable: res.data.mergeable
+        })
+    })
+
+    await Promise.all(merges)
     
     const promises = prs.map(async(pr) => {
         const conclusions = await octokit.request('GET /repos/{owner}/{repo}/commits/{ref}/check-runs', {
@@ -68,13 +81,14 @@ async function getPrs() {
     })
 
     const responses = await Promise.all(promises)
+
     prs = responses.map(res => {
         const hasFailureChecks = res.checks.check_runs.filter(check => {
             return ['action_required', 'failure'].includes(check.conclusion)
         }).length > 0
 
         if (hasFailureChecks) {
-            console.log(`PR ${res.pr.number} because it has failing checks`);
+            console.log(`Skiping PR ${res.pr.number} because it has failing checks`);
             return null
         }
         return res.pr

--- a/src/helper.js
+++ b/src/helper.js
@@ -54,20 +54,31 @@ async function getPrs() {
         base: target,
     })
 
-    const prs = data.filter(async(pr) => {
-        return !pr.draft
-    })
+    let prs = data.filter(pr => !pr.draft)
     
     const promises = prs.map(async(pr) => {
         const conclusions = await octokit.request('GET /repos/{owner}/{repo}/commits/{ref}/check-runs', {
             ...repoInfo,
-            ref: pr.head.ref
+            ref: pr.head.ref,
         })
-        return conclusions.data
+        return {
+            checks: conclusions.data,
+            pr
+        }
     })
 
     const responses = await Promise.all(promises)
-    console.log(responses)
+    prs = responses.map(res => {
+        const hasFailureChecks = res.checks.check_runs.filter(check => {
+            return ['action_required', 'failure'].includes(check.conclusion)
+        }).length > 0
+
+        if (hasFailureChecks) {
+            console.log(`PR ${res.pr.number} because it has failing checks`);
+            return null
+        }
+        return res.pr
+    }).filter( pr => pr)
 
     console.log(`Loading ${prs.length} PRs`)
     return prs

--- a/src/helper.js
+++ b/src/helper.js
@@ -1,3 +1,4 @@
+const core = require('@actions/core')
 const github = require('@actions/github')
 
 const { deployRefHead, deployRefName, repoInfo, token, target, ref, deployBranchName } = require('./constants')
@@ -8,40 +9,40 @@ const auxBranchName = `${deployRefHead}-${timestamp}`
 const auxBranchRef = `${deployRefName}-${timestamp}`
 
 async function getLastCommitSha() {
-    console.log(`Getting last commit from branch ${ref}`);
+    core.info(`Getting last commit from branch ${ref}`);
 
     const { data } = await octokit.rest.repos.getCommit({
         ...repoInfo,
         ref: ref
     })
 
-    console.log(`Successful get commit with message: ${data.commit.message}`);
+    core.info(`Successful get commit with message: ${data.commit.message}`);
 
     return data.sha
 }
 
 async function createAuxBranch(commitSha) {
-    console.log(`Creating branch ${auxBranchName}`)
+    core.info(`Creating branch ${auxBranchName}`)
     await createBranch(auxBranchName, commitSha)
-    console.log(`Successful create branch`)
+    core.info(`Successful create branch`)
 
     return auxBranchRef
 }
 
 async function deleteBranch(branchName) {
-    console.log(`Deleting branch ${branchName}`)
+    core.info(`Deleting branch ${branchName}`)
 
     try {
         await octokit.rest.git.deleteRef({
             ...repoInfo,
             ref: branchName,
         })   
-        console.log('Successful delete branch')
+        core.info('Successful delete branch')
     } catch (error) {
         if (error.message !== 'Reference does not exist') {
             throw Error('Unexpected error on delete branch')
         }
-        console.warn('Branch does not exists');
+        core.warning('Branch does not exists');
     }
 }
 
@@ -81,7 +82,7 @@ async function getPrs() {
         if (ms.mergeable) {
             return ms.pr
         }
-        console.log(`Skiping PR ${ms.pr.number} because it's not mergeable`);
+        core.info(`Skiping PR ${ms.pr.number} because it's not mergeable`);
         return null
     }). filter(pr => pr)
     
@@ -101,25 +102,29 @@ async function getPrs() {
 
     prs = checksResponses.map(res => {
         const hasFailureChecks = res.checks.check_runs.filter(check => {
-            return ['action_required', 'failure'].includes(check.conclusion)
+            /**
+             * For the releted PR, the action status will be (null) at this point because it's in progress.
+             * It prevents from skip current pr if last check run from this action had report failure status.
+             */
+            return ['action_required', 'cancelled', 'timed_out', 'failure'].includes(check.conclusion)
         }).length > 0
 
         if (hasFailureChecks) {
-            console.log(`Skiping PR ${res.pr.number} because it has failing checks`);
+            core.info(`Skiping PR ${res.pr.number} because it has failing checks`);
             return null
         }
         return res.pr
-    }).filter( pr => pr)
+    }).filter(pr => pr)
 
-    console.log(`Loading ${prs.length} PRs`)
+    core.info(`Loading ${prs.length} PRs`)
     return prs
 }
 
 async function recreateDeployBranch(commitSha) {
-    console.log(`Recreating branch ${deployRefHead}`)
+    core.info(`Recreating branch ${deployRefHead}`)
     await deleteBranch(deployRefName)
     await createBranch(deployRefHead, commitSha)
-    console.log(`Successful create branch`)
+    core.info(`Successful create branch`)
 }
 
 async function createBranch(branchName, commitSha) {
@@ -140,12 +145,12 @@ async function conflictDetails(head) {
         }
     })
     const { data: { html_url, permalink_url, diff_url, patch_url } } = res
-    console.log(`Para conferir detalhes do conflito veja os links: 
+    core.setFailed(`Para conferir detalhes do conflito veja os links: 
         html_url: ${html_url},
         permalink_url: ${permalink_url},
         diff_url: ${diff_url},
         patch_url: ${patch_url},
-    `);
+    `)
 }
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+const core = require('@actions/core')
 const { getLastCommitSha, createAuxBranch, deleteBranch, getPrs, mergeBranchs, recreateDeployBranch, conflictDetails } = require('./helper')
 
 async function run() {
@@ -11,18 +12,17 @@ async function run() {
     try {
         let lastMergeCommitSha
         for (let pull of pullRequests) {
-            console.log(`Merging PR ${pull.number}`)
+            core.info(`Merging PR ${pull.number}`)
             lastBranchToMerge = pull.head.ref
 
             const { data } = await mergeBranchs(pull.head.ref)
 
-            console.log(`Successful merge PR ${pull.number}`);
+            core.info(`Successful merge PR ${pull.number}`);
             
             lastMergeCommitSha = data.sha
         }
         await recreateDeployBranch(lastMergeCommitSha)
     } catch(error) {
-        console.log(error);
         await conflictDetails(lastBranchToMerge)
     } finally {
         await deleteBranch(workBranchName)

--- a/src/index.js
+++ b/src/index.js
@@ -22,9 +22,10 @@ async function run() {
         }
         await recreateDeployBranch(lastMergeCommitSha)
     } catch(error) {
+        console.log(error);
         await conflictDetails(lastBranchToMerge)
     } finally {
-        // await deleteBranch(workBranchName)
+        await deleteBranch(workBranchName)
     }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-const { getLastCommitSha, createAuxBranch, deleteBranch, getPrs, mergeBranchs, recreateDeployBranch } = require('./helper')
+const { getLastCommitSha, createAuxBranch, deleteBranch, getPrs, mergeBranchs, recreateDeployBranch, conflictDetails } = require('./helper')
 
 async function run() {
     const baseLastCommit = await getLastCommitSha()
@@ -7,10 +7,13 @@ async function run() {
 
     const pullRequests = await getPrs()
 
+    let lastBranchToMerge
     try {
         let lastMergeCommitSha
         for (let pull of pullRequests) {
             console.log(`Merging PR ${pull.number}`)
+            lastBranchToMerge = pull.head.ref
+
             const { data } = await mergeBranchs(pull.head.ref)
 
             console.log(`Successful merge PR ${pull.number}`);
@@ -18,8 +21,10 @@ async function run() {
             lastMergeCommitSha = data.sha
         }
         await recreateDeployBranch(lastMergeCommitSha)
+    } catch(error) {
+        await conflictDetails(lastBranchToMerge)
     } finally {
-        await deleteBranch(workBranchName)
+        // await deleteBranch(workBranchName)
     }
 }
 


### PR DESCRIPTION
Nessa nova versão o objetivo é trazer mais clareza quanto a localização dos conflitos de merge e também trazer ferramentas para que eles não aconteçam, como a filtragem dos PRs com conflitos de merge, requisições de prs pendentes ou com pedidos de mudanças além dos com checks falhando.

[Exemplo de execução](https://github.com/stone-ton/jarvis-web/actions/runs/4177216155)